### PR TITLE
Build/Packaging improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/hqx"]
 	path = submodules/hqx
-	url = git@github.com:grom358/hqx
+	url = https://github.com/grom358/hqx

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,21 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src
+SUBDIRS = . src
 EXTRA_DIST = THANKS tuxnes.xpm tuxnes2.xpm BUGS CHANGES
+
+# HQX especially needs -O3 for vectorization.
+# Overwrite the user-specified CFLAGS (default is generally -g -O2)
+# which has priority over AM_CFLAGS or any target-specific CFLAGS.
+CFLAGS = -O3
+
+if BUILD_HQX
+noinst_LIBRARIES = libhqx.a
+
+libhqx_a_SOURCES = \
+	submodules/hqx/src/init.c \
+	submodules/hqx/src/hq2x.c \
+	submodules/hqx/src/hq3x.c \
+	submodules/hqx/src/hq4x.c \
+	submodules/hqx/src/hqx.h \
+	submodules/hqx/src/common.h
+endif

--- a/README
+++ b/README
@@ -37,7 +37,7 @@ need to fetch it via:
 
     Next we may want to regenerate autoconf files:
 
-    $ sh autogen.sh
+    $ autoreconf -if
 
     From there we follow the normal autoconf process:
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-mkdir -p build-aux
-
-autoheader
-aclocal
-autoconf
-automake --add-missing

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([TuxNES],[0.75],[tuxnes-dev@dod.hpi.net])
+AC_INIT([TuxNES],[0.75],[https://github.com/tuxnes/tuxnes/issues])
 AC_CONFIG_SRCDIR([src/consts.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -6,8 +6,8 @@ AC_INIT([TuxNES],[0.75],[https://github.com/tuxnes/tuxnes/issues])
 AC_CONFIG_SRCDIR([src/consts.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_HEADERS([src/config.h])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_SILENT_RULES([yes])
 
 # Checks for programs.
 PKG_PROG_PKG_CONFIG
@@ -15,6 +15,7 @@ AC_PROG_CC
 AC_CHECK_TOOL([LD], [ld])
 AC_PROG_CC_C99
 AM_PROG_AS
+AC_PROG_RANLIB
 AC_PROG_INSTALL
 
 ## Check whether user wants simple warnings or advanced warnings
@@ -80,6 +81,15 @@ AS_IF([test "x$have_deflate" = "xyes"],[
 	AC_DEFINE([HAVE_LIBZ], [1], [Define to 1 if you have the `z' library (-lz).])
 ])
 
+PKG_CHECK_MODULES([HQX], [hqx],
+	[AS_VAR_SET([have_hqx], [yes])],
+	[AS_VAR_SET([have_hqx], [no])])
+AM_CONDITIONAL([BUILD_HQX], [test "x$have_hqx" = "xno"])
+AS_IF([test "x$have_hqx" = "xno"],[
+	AC_SUBST([HQX_CFLAGS], ['-I$(top_srcdir)/submodules/hqx/src'])
+	AC_SUBST([HQX_LIBS], ['$(top_builddir)/libhqx.a'])
+])
+
 AC_CHECK_LIB([pbm],[pbm_writepbm])
 AC_CHECK_LIB([pgm],[pgm_writepgm])
 AC_CHECK_LIB([ppm],[ppm_writeppm])
@@ -98,10 +108,6 @@ AS_IF([test "x$no_x" != "xyes"],[
 	LIBS="$save_LIBS"
 ])
 
-# HQX especially needs -O3 for vectorization
-AS_IF([test "x$enable_debug" = "xyes"],
-  [CFLAGS="-Wall -g -O0"],
-  [CFLAGS="-O3"])
-
 AC_CONFIG_FILES([Makefile src/Makefile])
+AC_CONFIG_HEADERS([src/config.h])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,4 @@
-AUTOMAKE_OPTIONS = subdir-objects
-
 AM_CFLAGS = $(WARNING_CFLAGS) $(PROFILING_CFLAGS)
-AM_CFLAGS += -I../submodules/hqx/src
-AM_CPPFLAGS = $(DEFLATE_CFLAGS) $(X_CFLAGS)
 
 bin_PROGRAMS = tuxnes
 bin_SCRIPTS = romfixer
@@ -27,13 +23,10 @@ tuxnes_SOURCES = \
 	sound.c sound.h \
 	renderer.c renderer.h \
 	screenshot.c screenshot.h \
-	x11.c \
-	../submodules/hqx/src/init.c \
-	../submodules/hqx/src/hq2x.c \
-	../submodules/hqx/src/hq3x.c \
-	../submodules/hqx/src/hq4x.c
+	x11.c
 
-tuxnes_LDADD = table.o $(DEFLATE_LIBS) $(X_LIBS)
+tuxnes_CPPFLAGS = $(AM_CPPFLAGS) $(DEFLATE_CFLAGS) $(HQX_CFLAGS) $(X_CFLAGS)
+tuxnes_LDADD = table.o $(DEFLATE_LIBS) $(HQX_LIBS) $(X_LIBS)
 tuxnes_LDFLAGS = $(AM_LDFLAGS) -Wl,-z,noexecstack
 
 comptbl_SOURCES = comptbl.c


### PR DESCRIPTION
Simplifying a few parts of the build system, for anyone starting from a fresh clone of this repo:

- `git submodule update --init` should no longer ask for a Github login.
- Switch to `autoreconf` which should make sure all autotools are run in the correct order.
- Build against the system HQX library if present, otherwise build HQX as a static lib.
- Allow user-specified CFLAGS to work as intended again (except for the HQX static lib which is forced to `-O3`).
- Silent rules now enabled for less cluttered build output.
- `make distcheck` is fixed, should now distribute enough of the HQX sources to build.